### PR TITLE
ARM Enhancents

### DIFF
--- a/src/main/java/nl/lxtreme/binutils/elf/ArmAeabiAttributesTag.java
+++ b/src/main/java/nl/lxtreme/binutils/elf/ArmAeabiAttributesTag.java
@@ -1,0 +1,163 @@
+/*
+ * BinUtils - access various binary formats from Java
+ *
+ * (C) Copyright 2018 - Matthias Bläsing - mblaesing@doppel-helix.eu
+ *
+ * Licensed under Apache License v2.
+ */
+package nl.lxtreme.binutils.elf;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class ArmAeabiAttributesTag<T> {
+
+    private final int value;
+    private final String name;
+    private final ArmParameterType<T> parameterType;
+
+    public ArmAeabiAttributesTag(int value, String name, ArmParameterType<T> parameterType) {
+        this.value = value;
+        this.name = name;
+        this.parameterType = parameterType;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ArmParameterType getParameterType() {
+        return parameterType;
+    }
+
+    @Override
+    public String toString() {
+        return name + " (" + value + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 67 * hash + this.value;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ArmAeabiAttributesTag other = (ArmAeabiAttributesTag) obj;
+        if (this.value != other.value) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final List<ArmAeabiAttributesTag> tags = new LinkedList<ArmAeabiAttributesTag>();
+    private static final Map<Integer, ArmAeabiAttributesTag> valueMap = new HashMap<Integer, ArmAeabiAttributesTag>();
+    private static final Map<String, ArmAeabiAttributesTag> nameMap = new HashMap<String, ArmAeabiAttributesTag>();
+
+    // Enumerated from ARM IHI 0045E, 2.5 Attributes summary and history
+    public static final ArmAeabiAttributesTag<Integer> File = addTag(1, "File", ArmParameterType.UINT32);
+    public static final ArmAeabiAttributesTag<Integer> Section = addTag(2, "Section", ArmParameterType.UINT32);
+    public static final ArmAeabiAttributesTag<Integer> Symbol = addTag(3, "Symbol", ArmParameterType.UINT32);
+    public static final ArmAeabiAttributesTag<String> CPU_raw_name = addTag(4, "CPU_raw_name", ArmParameterType.NTBS);
+    public static final ArmAeabiAttributesTag<String> CPU_name = addTag(5, "CPU_name", ArmParameterType.NTBS);
+    public static final ArmAeabiAttributesTag<BigInteger> CPU_arch = addTag(6, "CPU_arch", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> CPU_arch_profile = addTag(7, "CPU_arch_profile", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ARM_ISA_use = addTag(8, "ARM_ISA_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> THUMB_ISA_use= addTag(9, "THUMB_ISA_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> FP_arch = addTag(10, "FP_arch", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> WMMX_arch = addTag(11, "WMMX_arch", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> Advanced_SIMD_arch = addTag(12, "Advanced_SIMD_arch", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> PCS_config = addTag(13, "PCS_config", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_PCS_R9_use = addTag(14, "ABI_PCS_R9_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_PCS_RW_data = addTag(15, "ABI_PCS_RW_data", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_PCS_RO_data = addTag(16, "ABI_PCS_RO_data", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_PCS_GOT_use = addTag(17, "ABI_PCS_GOT_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_PCS_wchar_t = addTag(18, "ABI_PCS_wchar_t", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_FP_rounding = addTag(19, "ABI_FP_rounding", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_FP_denormal = addTag(20, "ABI_FP_denormal", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_FP_exceptions = addTag(21, "ABI_FP_exceptions", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_FP_user_exceptions = addTag(22, "ABI_FP_user_exceptions", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_FP_number_model = addTag(23, "ABI_FP_number_model", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_align_needed= addTag(24, "ABI_align_needed", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_align8_preserved = addTag(25, "ABI_align8_preserved", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_enum_size= addTag(26, "ABI_enum_size", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_HardFP_use = addTag(27, "ABI_HardFP_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_VFP_args = addTag(28, "ABI_VFP_args", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_WMMX_args = addTag(29, "ABI_WMMX_args", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_optimization_goals = addTag(30, "ABI_optimization_goals", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_FP_optimization_goals = addTag(31, "ABI_FP_optimization_goals", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<String> compatibility = addTag(32, "compatibility", ArmParameterType.NTBS);
+    public static final ArmAeabiAttributesTag<BigInteger> CPU_unaligned_access = addTag(34, "CPU_unaligned_access", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> FP_HP_extension = addTag(36, "FP_HP_extension", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> ABI_FP_16bit_format = addTag(38, "ABI_FP_16bit_format", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> MPextension_use = addTag(42, "MPextension_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> DIV_use = addTag(44, "DIV_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> nodefaults = addTag(64, "nodefaults", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<String> also_compatible_with = addTag(65, "also_compatible_with", ArmParameterType.NTBS);
+    public static final ArmAeabiAttributesTag<String> conformance = addTag(67, "conformance", ArmParameterType.NTBS);
+    public static final ArmAeabiAttributesTag<BigInteger> T2EE_use = addTag(66, "T2EE_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> Virtualization_use = addTag(68, "Virtualization_use", ArmParameterType.ULEB128);
+    public static final ArmAeabiAttributesTag<BigInteger> MPextension_use2 = addTag(70, "MPextension_use", ArmParameterType.ULEB128);
+
+    private static <S> ArmAeabiAttributesTag<S> addTag(int value, String name, ArmParameterType<S> type) {
+        ArmAeabiAttributesTag tag = new ArmAeabiAttributesTag(value, name, type);
+        
+        if (!valueMap.containsKey(tag.getValue())) {
+            valueMap.put(tag.getValue(), tag);
+        }
+        if (!nameMap.containsKey(tag.getName())) {
+            nameMap.put(tag.getName(), tag);
+        }
+        tags.add(tag);
+        return tag;
+    }
+
+    public static List<ArmAeabiAttributesTag> getTags() {
+        return Collections.unmodifiableList(tags);
+    }
+
+    public static ArmAeabiAttributesTag getByName(String name) {
+        return nameMap.get(name);
+    }
+
+    public static ArmAeabiAttributesTag getByValue(int value) {
+        if(valueMap.containsKey(value)) {
+            return valueMap.get(value);
+        } else {
+            ArmAeabiAttributesTag pseudoTag = new ArmAeabiAttributesTag(value, "Unknown " + value, getParameterType(value));
+            return pseudoTag;
+        }
+    }
+
+    private static ArmParameterType getParameterType(int value) {
+        // ARM IHI 0045E, 2.2.6 Coding extensibility and compatibility
+        ArmAeabiAttributesTag tag = getByValue(value);
+        if (tag == null) {
+            if ((value % 2) == 0) {
+                return ArmParameterType.ULEB128;
+            } else {
+                return ArmParameterType.NTBS;
+            }
+        } else {
+            return tag.getParameterType();
+        }
+    }
+}

--- a/src/main/java/nl/lxtreme/binutils/elf/ArmAttributes.java
+++ b/src/main/java/nl/lxtreme/binutils/elf/ArmAttributes.java
@@ -1,0 +1,61 @@
+/*
+ * BinUtils - access various binary formats from Java
+ *
+ * (C) Copyright 2018 - Matthias Bläsing - mblaesing@doppel-helix.eu
+ *
+ * Licensed under Apache License v2.
+ */
+package nl.lxtreme.binutils.elf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+class ArmAttributes {
+    /**
+     * Name of pseudo vendor for ARM Eabi attributes
+     */
+    public static final String AEABI = "aeabi";
+    private Map<String,ByteBuffer> attributeBuffers = new HashMap<>();
+
+    public ArmAttributes(ByteBuffer bb) throws IOException
+    {
+        byte format = bb.get();
+        if (format != 0x41)
+        {
+            // Version A
+            // Not supported
+            throw new IOException(String.format("Unrecognized format: %02x", format));
+        }
+
+        Map<String,Map<Integer,Map<ArmAeabiAttributesTag,Object>>> result = new HashMap<>();
+        while (bb.position() < bb.limit()) {
+            int posSectionStart = bb.position();
+            int sectionLength = bb.getInt();
+            if (sectionLength <= 0) {
+                // Fail!
+                break;
+            }
+
+            String vendorName = ArmParameterType.NTBS.readFromByteBuffer(bb);
+
+            ByteBuffer sectionData = bb.slice();
+            sectionData.order(bb.order());
+            sectionData.limit(sectionLength - (bb.position() - posSectionStart));
+
+            attributeBuffers.put(vendorName, sectionData);
+
+            bb.position(posSectionStart + sectionLength);
+        }
+    }
+
+    public boolean hasVendorName(String name) {
+        return attributeBuffers.containsKey(name);
+    }
+
+    public ByteBuffer getByVendorName(String name) {
+        return attributeBuffers.get(name);
+    }
+
+}

--- a/src/main/java/nl/lxtreme/binutils/elf/ArmAttributesTag.java
+++ b/src/main/java/nl/lxtreme/binutils/elf/ArmAttributesTag.java
@@ -1,0 +1,164 @@
+/*
+ * BinUtils - access various binary formats from Java
+ *
+ * (C) Copyright 2018 - Matthias Bläsing - mblaesing@doppel-helix.eu
+ *
+ * Licensed under Apache License v2.
+ */
+package nl.lxtreme.binutils.elf;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+
+class ArmAttributesTag<T> {
+
+    private final int value;
+    private final String name;
+    private final ArmParameterType<T> parameterType;
+
+    public ArmAttributesTag(int value, String name, ArmParameterType<T> parameterType) {
+        this.value = value;
+        this.name = name;
+        this.parameterType = parameterType;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ArmParameterType<T> getParameterType() {
+        return parameterType;
+    }
+
+    @Override
+    public String toString() {
+        return name + " (" + value + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 67 * hash + this.value;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ArmAttributesTag other = (ArmAttributesTag) obj;
+        if (this.value != other.value) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final List<ArmAttributesTag> tags = new LinkedList<ArmAttributesTag>();
+    private static final Map<Integer, ArmAttributesTag> valueMap = new HashMap<Integer, ArmAttributesTag>();
+    private static final Map<String, ArmAttributesTag> nameMap = new HashMap<String, ArmAttributesTag>();
+
+    // Enumerated from ARM IHI 0045E, 2.5 Attributes summary and history
+    public static final ArmAttributesTag<Integer> File = addTag(1, "File", ArmParameterType.UINT32);
+    public static final ArmAttributesTag<Integer> Section = addTag(2, "Section", ArmParameterType.UINT32);
+    public static final ArmAttributesTag<Integer> Symbol = addTag(3, "Symbol", ArmParameterType.UINT32);
+    public static final ArmAttributesTag<String> CPU_raw_name = addTag(4, "CPU_raw_name", ArmParameterType.NTBS);
+    public static final ArmAttributesTag<String> CPU_name = addTag(5, "CPU_name", ArmParameterType.NTBS);
+    public static final ArmAttributesTag<BigInteger> CPU_arch = addTag(6, "CPU_arch", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> CPU_arch_profile = addTag(7, "CPU_arch_profile", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ARM_ISA_use = addTag(8, "ARM_ISA_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> THUMB_ISA_use= addTag(9, "THUMB_ISA_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> FP_arch = addTag(10, "FP_arch", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> WMMX_arch = addTag(11, "WMMX_arch", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> Advanced_SIMD_arch = addTag(12, "Advanced_SIMD_arch", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> PCS_config = addTag(13, "PCS_config", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_PCS_R9_use = addTag(14, "ABI_PCS_R9_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_PCS_RW_data = addTag(15, "ABI_PCS_RW_data", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_PCS_RO_data = addTag(16, "ABI_PCS_RO_data", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_PCS_GOT_use = addTag(17, "ABI_PCS_GOT_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_PCS_wchar_t = addTag(18, "ABI_PCS_wchar_t", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_FP_rounding = addTag(19, "ABI_FP_rounding", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_FP_denormal = addTag(20, "ABI_FP_denormal", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_FP_exceptions = addTag(21, "ABI_FP_exceptions", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_FP_user_exceptions = addTag(22, "ABI_FP_user_exceptions", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_FP_number_model = addTag(23, "ABI_FP_number_model", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_align_needed= addTag(24, "ABI_align_needed", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_align8_preserved = addTag(25, "ABI_align8_preserved", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_enum_size= addTag(26, "ABI_enum_size", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_HardFP_use = addTag(27, "ABI_HardFP_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_VFP_args = addTag(28, "ABI_VFP_args", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_WMMX_args = addTag(29, "ABI_WMMX_args", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_optimization_goals = addTag(30, "ABI_optimization_goals", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_FP_optimization_goals = addTag(31, "ABI_FP_optimization_goals", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<String> compatibility = addTag(32, "compatibility", ArmParameterType.NTBS);
+    public static final ArmAttributesTag<BigInteger> CPU_unaligned_access = addTag(34, "CPU_unaligned_access", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> FP_HP_extension = addTag(36, "FP_HP_extension", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> ABI_FP_16bit_format = addTag(38, "ABI_FP_16bit_format", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> MPextension_use = addTag(42, "MPextension_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> DIV_use = addTag(44, "DIV_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> nodefaults = addTag(64, "nodefaults", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<String> also_compatible_with = addTag(65, "also_compatible_with", ArmParameterType.NTBS);
+    public static final ArmAttributesTag<String> conformance = addTag(67, "conformance", ArmParameterType.NTBS);
+    public static final ArmAttributesTag<BigInteger> T2EE_use = addTag(66, "T2EE_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> Virtualization_use = addTag(68, "Virtualization_use", ArmParameterType.ULEB128);
+    public static final ArmAttributesTag<BigInteger> MPextension_use2 = addTag(70, "MPextension_use", ArmParameterType.ULEB128);
+
+    private static <S> ArmAttributesTag<S> addTag(int value, String name, ArmParameterType<S> type) {
+        ArmAttributesTag tag = new ArmAttributesTag(value, name, type);
+
+        if (!valueMap.containsKey(tag.getValue())) {
+            valueMap.put(tag.getValue(), tag);
+        }
+        if (!nameMap.containsKey(tag.getName())) {
+            nameMap.put(tag.getName(), tag);
+        }
+        tags.add(tag);
+        return tag;
+    }
+
+    public static List<ArmAttributesTag> getTags() {
+        return Collections.unmodifiableList(tags);
+    }
+
+    public static ArmAttributesTag getByName(String name) {
+        return nameMap.get(name);
+    }
+
+    public static ArmAttributesTag getByValue(int value) {
+        if(valueMap.containsKey(value)) {
+            return valueMap.get(value);
+        } else {
+            ArmAttributesTag pseudoTag = new ArmAttributesTag(value, "Unknown " + value, getParameterType(value));
+            return pseudoTag;
+        }
+    }
+
+    private static ArmParameterType getParameterType(int value) {
+        // ARM IHI 0045E, 2.2.6 Coding extensibility and compatibility
+        ArmAttributesTag tag = getByValue(value);
+        if (tag == null) {
+            if ((value % 2) == 0) {
+                return ArmParameterType.ULEB128;
+            } else {
+                return ArmParameterType.NTBS;
+            }
+        } else {
+            return tag.getParameterType();
+        }
+    }
+}

--- a/src/main/java/nl/lxtreme/binutils/elf/ArmEabiAttributes.java
+++ b/src/main/java/nl/lxtreme/binutils/elf/ArmEabiAttributes.java
@@ -1,0 +1,48 @@
+/*
+ * BinUtils - access various binary formats from Java
+ *
+ * (C) Copyright 2018 - Matthias Bläsing - mblaesing@doppel-helix.eu
+ *
+ * Licensed under Apache License v2.
+ */
+package nl.lxtreme.binutils.elf;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ArmEabiAttributes
+{
+    private Map<ArmAeabiAttributesTag, Object> fileAttributes = Collections.EMPTY_MAP;
+
+    public ArmEabiAttributes(ByteBuffer buffer) {
+        while (buffer.position() < buffer.limit()) {
+            int pos = buffer.position();
+            int subsectionTag = ArmParameterType.ULEB128.readFromByteBuffer(buffer).intValue();
+            int length = buffer.getInt();
+            if (subsectionTag ==  ArmAeabiAttributesTag.File.getValue()) {
+                fileAttributes = parseFileAttribute(buffer);
+            }
+            buffer.position(pos + length);
+        }
+    }
+
+    public Map<ArmAeabiAttributesTag, Object> getFileAttributes() {
+        return fileAttributes;
+    }
+
+    public <T> T getFileAttribute(ArmAeabiAttributesTag<T> tag) {
+        return (T) fileAttributes.get(tag);
+    }
+
+    private static Map<ArmAeabiAttributesTag, Object> parseFileAttribute(ByteBuffer bb) {
+        Map<ArmAeabiAttributesTag, Object> result = new HashMap<>();
+        while (bb.position() < bb.limit()) {
+            int tagValue = ArmParameterType.ULEB128.readFromByteBuffer(bb).intValue();
+            ArmAeabiAttributesTag tag = ArmAeabiAttributesTag.getByValue(tagValue);
+            result.put(tag, tag.getParameterType().readFromByteBuffer(bb));
+        }
+        return result;
+    }
+}

--- a/src/main/java/nl/lxtreme/binutils/elf/ArmParameterType.java
+++ b/src/main/java/nl/lxtreme/binutils/elf/ArmParameterType.java
@@ -1,0 +1,80 @@
+/*
+ * BinUtils - access various binary formats from Java
+ *
+ * (C) Copyright 2018 - Matthias Bläsing - mblaesing@doppel-helix.eu
+ *
+ * Licensed under Apache License v2.
+ */
+package nl.lxtreme.binutils.elf;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+public abstract class ArmParameterType<T>
+{
+
+    public static final ArmParameterType<Integer> UINT32 = new ArmParameterType<Integer>(Integer.class)
+    {
+        @Override
+        public Integer readFromByteBuffer(ByteBuffer bb)
+        {
+            return bb.getInt();
+        }
+    };
+    public static final ArmParameterType<String> NTBS = new ArmParameterType<String>(String.class)
+    {
+        @Override
+        public String readFromByteBuffer(ByteBuffer bb)
+        {
+            int startingPos = bb.position();
+            byte currentByte;
+            do
+            {
+                currentByte = bb.get();
+            } while (currentByte != '\0' && bb.position() <= bb.limit());
+            int terminatingPosition = bb.position();
+            byte[] data = new byte[terminatingPosition - startingPos - 1];
+            bb.position(startingPos);
+            bb.get(data);
+            bb.position(bb.position() + 1);
+            try
+            {
+                return new String(data, "ASCII");
+            } catch (UnsupportedEncodingException ex)
+            {
+                throw new RuntimeException(ex);
+            }
+        }
+    };
+    public static final ArmParameterType<BigInteger> ULEB128 = new ArmParameterType<BigInteger>(BigInteger.class)
+    {
+        @Override
+        public BigInteger readFromByteBuffer(ByteBuffer bb)
+        {
+            BigInteger result = BigInteger.ZERO;
+            int shift = 0;
+            while (true)
+            {
+                byte b = bb.get();
+                result = result.or(BigInteger.valueOf(b & 127).shiftLeft(shift));
+                if ((b & 128) == 0)
+                {
+                    break;
+                }
+                shift += 7;
+            }
+            return result;
+        }
+    };
+
+    private final Class<T> javaRepresentation;
+
+    public ArmParameterType(Class<T> javaRepresentation)
+    {
+        this.javaRepresentation = javaRepresentation;
+    }
+
+    public abstract T readFromByteBuffer(ByteBuffer bb);
+
+}

--- a/src/main/java/nl/lxtreme/binutils/elf/SectionType.java
+++ b/src/main/java/nl/lxtreme/binutils/elf/SectionType.java
@@ -38,6 +38,11 @@ public class SectionType {
     public static final SectionType GNU_VERDEF = new SectionType(0x6ffffffd, "GNU version definition section");
     public static final SectionType GNU_VERNEED = new SectionType(0x6ffffffe, "GNU version needs section");
     public static final SectionType GNU_VERSYM = new SectionType(0x6fffffff, "GNU version symbol table");
+    public static final SectionType SHT_ARM_EXIDX = new SectionType(0x70000001, "Exception Index table");
+    public static final SectionType SHT_ARM_PREEMPTMAP = new SectionType(0x70000002, "BPABI DLL dynamic linking pre-emption map");
+    public static final SectionType SHT_ARM_ATTRIBUTES = new SectionType(0x70000003, "Object file compatibility attributes");
+    public static final SectionType SHT_ARM_DEBUGOVERLAY = new SectionType(0x70000004, "DBGOVL 1");
+    public static final SectionType SHT_ARM_OVERLAYSECTION = new SectionType(0x70000005, "DBGOVL 2");
 
     private static final SectionType[] VALUES = { NULL, PROGBITS, SYMTAB, STRTAB, RELA, HASH, DYNAMIC, NOTE, NOBITS,
         REL, SHLIB, DYNSYM, INIT_ARRAY, FINI_ARRAY, PREINIT_ARRAY, GROUP, SYMTAB_SHNDX, GNU_ATTRIBUTES, GNU_HASH,

--- a/src/main/java/nl/lxtreme/binutils/elf/SectionType.java
+++ b/src/main/java/nl/lxtreme/binutils/elf/SectionType.java
@@ -43,12 +43,12 @@ public class SectionType {
         REL, SHLIB, DYNSYM, INIT_ARRAY, FINI_ARRAY, PREINIT_ARRAY, GROUP, SYMTAB_SHNDX, GNU_ATTRIBUTES, GNU_HASH,
         GNU_LIBLIST, CHECKSUM, SUNW_MOVE, SUNW_COMDAT, SUNW_SYMINFO, GNU_VERDEF, GNU_VERNEED, GNU_VERSYM };
 
-    private static final int SHT_LOOS = 0x60000000;
-    private static final int SHT_HIOS = 0x6fffffff;
-    private static final int SHT_LOPROC = 0x70000000;
-    private static final int SHT_HIPROC = 0x7fffffff;
-    private static final int SHT_LOUSER = 0x70000000;
-    private static final int SHT_HIUSER = 0x7fffffff;
+    private static final long SHT_LOOS = 0x60000000L;
+    private static final long SHT_HIOS = 0x6fffffffL;
+    private static final long SHT_LOPROC = 0x70000000L;
+    private static final long SHT_HIPROC = 0x7fffffffL;
+    private static final long SHT_LOUSER = 0x80000000L;
+    private static final long SHT_HIUSER = 0xffffffffL;
 
     public static SectionType valueOf(int value) {
         for (SectionType st : VALUES) {

--- a/src/test/java/nl/lxtreme/binutils/elf/ArmAttributesTest.java
+++ b/src/test/java/nl/lxtreme/binutils/elf/ArmAttributesTest.java
@@ -1,0 +1,53 @@
+/*
+ * BinUtils - access various binary formats from Java
+ *
+ * (C) Copyright 2018 - Matthias Bläsing - mblaesing@doppel-helix.eu
+ *
+ * Licensed under Apache License v2.
+ */
+package nl.lxtreme.binutils.elf;
+
+import java.io.File;
+import java.net.URL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class ArmAttributesTest
+{
+
+    @Test
+    public void testReadingBuildFlags() throws Exception
+    {
+        Elf elf = new Elf(getResource("ts_print"));
+        for (SectionHeader sh : elf.sectionHeaders)
+        {
+            if (".ARM.attributes".equals(sh.getName()))
+            {
+                ArmAttributes armAttributes = new ArmAttributes(elf.getSection(sh));
+                if (armAttributes.hasVendorName(ArmAttributes.AEABI))
+                {
+                    ArmEabiAttributes eabi = new ArmEabiAttributes(armAttributes.getByVendorName(ArmAttributes.AEABI));
+                    assertEquals(0x04, eabi.getFileAttribute(ArmAeabiAttributesTag.CPU_arch).intValue());
+                    assertEquals(0x01, eabi.getFileAttribute(ArmAeabiAttributesTag.ARM_ISA_use).intValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * @param aName
+     * @return
+     * @throws URISyntaxException
+     */
+    private File getResource(String aName) throws Exception
+    {
+        URL url = getClass().getClassLoader().getResource(aName);
+        if ((url != null) && "file".equals(url.getProtocol()))
+        {
+            return new File(url.getPath()).getCanonicalFile();
+        }
+        fail("Resource " + aName + " not found!");
+        return null; // to keep compiler happy...
+    }
+}


### PR DESCRIPTION
For the JNA project I needed a way to determine whether an ELF binary
for ARM is compiled as a softfloat or hardfloat variant. For that implementation
I was inspired by java-binutils. In the end I did not use the code from the
project, but I think the parsing code for the ARM build attributes might also be
interesting for others.

I cleaned up the code and so I propose it for inclusion into java-binutils.